### PR TITLE
fix: configure js-yaml as external package to resolve esprima module error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
       bodySizeLimit: '2mb',
     },
   },
+  serverComponentsExternalPackages: ['js-yaml'],
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Fixes the module loading error when navigating to /study/domain-1-organizational-complexity.

The issue occurred because Next.js was attempting to bundle js-yaml (which depends on esprima) for server components. This fix adds js-yaml to serverComponentsExternalPackages in next.config.js, telling Next.js to use the Node.js module directly instead of bundling it.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)