### PR TITLE
Fix markdown table rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^18.3.0",
     "react-markdown": "^10.1.0",
     "recharts": "^3.6.0",
+    "remark-gfm": "^4.0.0",
     "tailwind-merge": "^2.5.0"
   },
   "devDependencies": {

--- a/src/components/study/StudyContent.tsx
+++ b/src/components/study/StudyContent.tsx
@@ -1,4 +1,5 @@
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { Separator } from '@/components/ui/separator';
 
 interface StudyContentProps {
@@ -9,6 +10,7 @@ export function StudyContent({ content }: StudyContentProps) {
   return (
     <div className="study-content">
       <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
         components={{
           // Headings
           h1: ({ children }) => (

--- a/src/components/tutor/TutorPanel.tsx
+++ b/src/components/tutor/TutorPanel.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Loader2, Send, Sparkles, MessageCircle } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import type { TutorContext } from '@/lib/claude/prompts';
 
 interface Message {
@@ -149,7 +150,7 @@ export function TutorPanel({ open, onOpenChange, context }: TutorPanelProps) {
                 >
                   {message.role === 'assistant' ? (
                     <div className="prose prose-sm dark:prose-invert max-w-none">
-                      <ReactMarkdown>{message.content}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
                     </div>
                   ) : (
                     <p className="text-sm">{message.content}</p>


### PR DESCRIPTION
## Summary
Fixes markdown tables not rendering properly throughout the app.

## Changes
- Added `remark-gfm` dependency to enable GitHub Flavored Markdown table parsing
- Updated `StudyContent` component to use `remarkGfm` plugin
- Updated `TutorPanel` component to use `remarkGfm` plugin

Resolves #8

🤖 Generated with [Claude Code](https://claude.ai/code)